### PR TITLE
Fix grammar in documentation

### DIFF
--- a/docs/cpu_todo.md
+++ b/docs/cpu_todo.md
@@ -146,7 +146,7 @@ Translates to (something like):
   vor(xmm2, xmm2, xmm2)
 ```
 
-Where as it could be:
+Whereas it could be:
 ```
   vor(xmm2, xmm2, [rip+0x...])
 ```


### PR DESCRIPTION
## Summary
- fix minor grammar in docs/cpu_todo.md

## Testing
- `./xb test` *(fails: premake executable/build not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f95295ac0832eb57debf4130e22b2