### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/cpu.md
+++ b/docs/cpu.md
@@ -106,7 +106,7 @@ addi      r11, r9, 0x200
 rlwinm    r11, r11, 0,19,19 # r11 = r11 & 0x1000
 add       r11, r11, r10     # add 1 page to addresses > 0xE0000000
 
-# r11 = addess passed to GPU
+# r11 = address passed to GPU
 ```
 
 ## Memory Management


### PR DESCRIPTION
## Summary
- fix a small typo in `docs/cpu.md`

## Testing
- `./xb gentests` *(fails: FileNotFoundError: third_party/binutils-ppc-cygwin/powerpc-none-elf-as)*
- `./xb test` *(fails: No rule to make target 'Bootstrap.mak')*

------
https://chatgpt.com/codex/tasks/task_e_683f951c32f0832e9c64e156c5d8ab17